### PR TITLE
fix: align slonik connection types

### DIFF
--- a/lib/loaders/create-node-loader-class.ts
+++ b/lib/loaders/create-node-loader-class.ts
@@ -3,7 +3,7 @@ import { snakeCase } from "snake-case";
 
 import {
   sql,
-  DatabasePoolType,
+  CommonQueryMethodsType,
   TaggedTemplateLiteralInvocationType,
   SqlTokenType,
 } from "slonik";
@@ -39,7 +39,7 @@ export const createNodeLoaderClass = <TRecord, TContext = unknown>(config: {
     string
   > {
     constructor(
-      connection: DatabasePoolType,
+      connection: CommonQueryMethodsType,
       context: TContext,
       loaderOptions?: DataLoader.Options<
         PrimitiveValueExpressionType,


### PR DESCRIPTION
At the moment, there is an issue where a connection in the form of a transaction (`DatabaseTransactionConnectionType`) -- not a pool (`DatabasePoolType`) -- cannot be passed to `createNodeLoaderClass`. This PR aligns the types of the Slonik `connection` that both `createNodeLoaderClass` and `createConnectionLoaderClass` expect to be consistent.