### PR TITLE
feat: Added dynamic query function

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,35 @@ const UserConnectionLoader = createConnectionLoaderClass<
 
 In the example above, if the field on the Edge type in the schema is named `createdAt`, we just need to write a resolver for it and resolve the value to that of the `edgeCreatedAt` property.
 
+#### Dynamic queries
+
+If you need more flexibility, it's possible to dynamically build queries by specifying a function instead of a static query.
+The function must return a slonik query, and it takes any arguments as input. For example:
+
+```ts
+const UserConnectionLoader = createConnectionLoaderClass<
+  User & { edgeCreatedAt }
+>({
+  query: ({ friendName }: { friendName: string }) => sql.unsafe`
+    SELECT
+      user.*
+    FROM user
+    INNER JOIN friend ON
+      user.id = friend.user_id
+    WHERE friend.name ILIKE ${sql.literalValue(args.friendName)}
+  `,
+});
+```
+
+Those arguments can then be passed down while loading
+
+```ts
+const connection = await loader.load({
+  args: { friendName: 'bob' }
+  orderBy: ({ name }) => [[name, "ASC"]],
+});
+```
+
 ### `columnNameTransformer`
 
 Both types of loaders also accept an `columnNameTransformer` option. By default, the transformer used is [snake-case](https://www.npmjs.com/package/snake-case). The default assumes:

--- a/lib/loaders/createConnectionLoaderClass.ts
+++ b/lib/loaders/createConnectionLoaderClass.ts
@@ -11,7 +11,7 @@ import {
   toCursor,
 } from "../utilities";
 
-export type DataLoaderKey<TResult, TArgs> = {
+export type DataLoaderKey<TResult, TArgs=never> = {
   cursor?: string | null;
   limit?: number | null;
   reverse?: boolean;
@@ -26,7 +26,7 @@ export type DataLoaderKey<TResult, TArgs> = {
 const SORT_COLUMN_ALIAS = "s1";
 const TABLE_ALIAS = "t1";
 
-export const createConnectionLoaderClass = <T extends ZodTypeAny, TArgs>(config: {
+export const createConnectionLoaderClass = <T extends ZodTypeAny, TArgs=never>(config: {
   columnNameTransformer?: (column: string) => string;
   query: QuerySqlToken<T> | ((args?: TArgs) => QuerySqlToken<T>);
 }) => {

--- a/lib/loaders/createConnectionLoaderClass.ts
+++ b/lib/loaders/createConnectionLoaderClass.ts
@@ -11,10 +11,11 @@ import {
   toCursor,
 } from "../utilities";
 
-export type DataLoaderKey<TResult> = {
+export type DataLoaderKey<TResult, TArgs> = {
   cursor?: string | null;
   limit?: number | null;
   reverse?: boolean;
+  args?: TArgs;
   orderBy?: (
     identifiers: ColumnIdentifiers<TResult>
   ) => [SqlToken, OrderDirection][];
@@ -25,25 +26,25 @@ export type DataLoaderKey<TResult> = {
 const SORT_COLUMN_ALIAS = "s1";
 const TABLE_ALIAS = "t1";
 
-export const createConnectionLoaderClass = <T extends ZodTypeAny>(config: {
+export const createConnectionLoaderClass = <T extends ZodTypeAny, TArgs>(config: {
   columnNameTransformer?: (column: string) => string;
-  query: QuerySqlToken<T>;
+  query: QuerySqlToken<T> | ((args?: TArgs) => QuerySqlToken<T>);
 }) => {
-  const { columnNameTransformer = snakeCase, query } = config;
+  const { columnNameTransformer = snakeCase } = config;
   const columnIdentifiers = getColumnIdentifiers<z.infer<T>>(
     TABLE_ALIAS,
     columnNameTransformer
   );
 
   return class ConnectionLoaderClass extends DataLoader<
-    DataLoaderKey<z.infer<T>>,
+    DataLoaderKey<z.infer<T>, TArgs>,
     Connection<z.infer<T>>,
     string
   > {
     constructor(
       pool: CommonQueryMethods,
       dataLoaderOptions?: DataLoader.Options<
-        DataLoaderKey<z.infer<T>>,
+        DataLoaderKey<z.infer<T>, TArgs>,
         Connection<z.infer<T>>,
         string
       >
@@ -52,8 +53,9 @@ export const createConnectionLoaderClass = <T extends ZodTypeAny>(config: {
         async (loaderKeys) => {
           const edgesQueries: QuerySqlToken[] = [];
           const countQueries: QuerySqlToken[] = [];
-
+          
           loaderKeys.forEach((loaderKey, index) => {
+            const query = typeof config.query === 'function' ? config.query(loaderKey.args) : config.query;
             const {
               cursor,
               info,
@@ -183,7 +185,7 @@ export const createConnectionLoaderClass = <T extends ZodTypeAny>(config: {
             }
           });
 
-          const parser = query.parser as unknown as AnyZodObject;
+          const parser = (typeof config.query === 'function' ? config.query().parser : config.query.parser) as unknown as AnyZodObject;
 
           // @ts-expect-error Accessing internal property to determine if parser is an instance of z.any()
           const extendedParser = parser._any === true ? z.object({
@@ -278,6 +280,7 @@ export const createConnectionLoaderClass = <T extends ZodTypeAny>(config: {
             info,
             limit,
             orderBy,
+            args,
             reverse = false,
             where,
           }) => {
@@ -289,7 +292,7 @@ export const createConnectionLoaderClass = <T extends ZodTypeAny>(config: {
               orderBy?.(columnIdentifiers)
             )}|${JSON.stringify(
               where?.(columnIdentifiers)
-            )}|${requestedFields.values()}`;
+            )}|${requestedFields.values()}|${JSON.stringify(args)}`;
           },
         }
       );


### PR DESCRIPTION
This change is backwards compatible, it adds the option to specify a function in the query.
The main use case here is to allow more complex filters to be used on inner fields that aren't exposed, but other use cases are also possible, e.g. it makes combining with other query builders and slonik helper utilities easier.
